### PR TITLE
Binishma ss copyright year change

### DIFF
--- a/README-fr_FR.md
+++ b/README-fr_FR.md
@@ -66,7 +66,7 @@ Si vous voulez contribuer et vous impliquer dans notre communauté, voici les re
 
 ## Licence
 
-Copyright 2020-2024 © Les auteurs de Backstage. Tous droits réservés. La Linux Foundation détient des marques déposées et utilise des marques commerciales. Pour une liste des marques de commerce de la Linux Foundation, veuillez consulter notre page d'utilisation des marques: https://www.linuxfoundation.org/trademark-usage
+Copyright 2020-2025 © Les auteurs de Backstage. Tous droits réservés. La Linux Foundation détient des marques déposées et utilise des marques commerciales. Pour une liste des marques de commerce de la Linux Foundation, veuillez consulter notre page d'utilisation des marques: https://www.linuxfoundation.org/trademark-usage
 
 Sous licence Apache, version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/README-ko_kr.md
+++ b/README-ko_kr.md
@@ -65,7 +65,7 @@ Backstage의 문서는 다음을 포함합니다:
 
 ## License
 
-Copyright 2020-2024 © The Backstage Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage
+Copyright 2020-2025 © The Backstage Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 

--- a/README-zh_Hans.md
+++ b/README-zh_Hans.md
@@ -65,7 +65,7 @@ Backstage 的文档包括：
 
 ## 许可
 
-版权所有 2020-2024 © Backstage 作者。版权所有。Linux 基金会已注册商标并使用商标。有关 Linux 基金会的商标列表，请参阅我们的商标使用页面：https://www.linuxfoundation.org/trademark-usage
+版权所有 2020-2025 © Backstage 作者。版权所有。Linux 基金会已注册商标并使用商标。有关 Linux 基金会的商标列表，请参阅我们的商标使用页面：https://www.linuxfoundation.org/trademark-usage
 
 采用 Apache v2.0 许可：http://www.apache.org/licenses/LICENSE-2.0
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See the [GOVERNANCE.md](https://github.com/backstage/community/blob/main/GOVERNA
 
 ## License
 
-Copyright 2020-2024 © The Backstage Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage
+Copyright 2020-2025 © The Backstage Authors. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our Trademark Usage page: https://www.linuxfoundation.org/trademark-usage
 
 Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
Updated Copyright year from 2020-2024 to 2020-2025 in 
README.md, 
README-zh_Hans.md, 
README-ko_kr.md and 
README-fr_FR.md files